### PR TITLE
Bugfix/transactional

### DIFF
--- a/.github/workflows/fix_tournaments.yml
+++ b/.github/workflows/fix_tournaments.yml
@@ -1,0 +1,137 @@
+name: Fix Tournaments
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Maximum tournaments to process (leave blank for all)"
+        required: false
+        type: string
+      include_unfinalized:
+        description: "Include tournaments not marked finalized"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      log_level:
+        description: "Log verbosity"
+        required: false
+        default: "INFO"
+        type: choice
+        options:
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+          - CRITICAL
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    environment: Scraper
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Get self ip
+        id: self_ip
+        run: |
+          SELF_IP=$(curl -s https://api.ipify.org)
+          echo "self_ip=$SELF_IP" >> $GITHUB_OUTPUT
+
+      - name: Terraform Init
+        working-directory: terraform/scraper
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: terraform/scraper
+        run: terraform plan -out=tfplan -input=false
+        env:
+          TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          TF_VAR_source_ip: ${{ steps.self_ip.outputs.self_ip }}
+          TF_VAR_joy_ip: ${{ secrets.JOY_IP }}
+
+      - name: Terraform Apply
+        id: terraform_apply
+        working-directory: terraform/scraper
+        run: |
+          terraform apply -auto-approve tfplan
+          SCRAPER_IP=$(terraform output -raw scraper_ip)
+          SCRAPER_ID=$(terraform output -raw scraper_id)
+          echo "scraper_ip=$SCRAPER_IP" >> $GITHUB_OUTPUT
+          echo "scraper_id=$SCRAPER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for droplet
+        run: sleep 90
+
+      - name: Run fix command
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ steps.terraform_apply.outputs.scraper_ip }}
+          username: root
+          key: ${{ secrets.DIGITALOCEAN_SSH_KEY_ED }}
+          script: |
+            set +o histexpand || true
+            export PATH=$PATH:/usr/bin
+            export DO_API_TOKEN='${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}'
+            export RANKINGS_DATABASE_URL='${{ secrets.RANKINGS_DATABASE_URL }}'
+            export RANKINGS_DB_SCHEMA='${{ secrets.RANKINGS_DB_SCHEMA }}'
+            export SENDOU_KEY='${{ secrets.SENDOU_KEY }}'
+            export SENTRY_DSN='${{ secrets.SENTRY_DSN }}'
+
+            if [ -z "$RANKINGS_DATABASE_URL" ]; then
+              echo "RANKINGS_DATABASE_URL secret is required" >&2
+              exit 1
+            fi
+            if [ -z "$SENDOU_KEY" ]; then
+              echo "SENDOU_KEY secret is required" >&2
+              exit 1
+            fi
+
+            LIMIT_INPUT='${{ inputs.limit }}'
+            ARG_LIMIT=""
+            if [ -n "$LIMIT_INPUT" ]; then
+              if ! echo "$LIMIT_INPUT" | grep -Eq '^[0-9]+$'; then
+                echo "limit must be numeric" >&2
+                exit 1
+              fi
+              ARG_LIMIT="--limit $LIMIT_INPUT"
+            fi
+
+            INCLUDE_UNFINALIZED='${{ inputs.include_unfinalized }}'
+            ARG_UNFINALIZED=""
+            if [ "$INCLUDE_UNFINALIZED" = "true" ]; then
+              ARG_UNFINALIZED="--include-unfinalized"
+            fi
+
+            LOG_LEVEL='${{ inputs.log_level }}'
+
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+
+            docker login -u "$DO_API_TOKEN" -p "$DO_API_TOKEN" registry.digitalocean.com/sendouq
+            docker pull registry.digitalocean.com/sendouq/scraper:latest
+
+            docker run --rm \
+              -e RANKINGS_DATABASE_URL \
+              -e RANKINGS_DB_SCHEMA \
+              -e SENDOU_KEY \
+              -e SENTRY_DSN \
+              --entrypoint poetry \
+              registry.digitalocean.com/sendouq/scraper:latest \
+              run rankings_fix_tournaments --log-level "$LOG_LEVEL" $ARG_LIMIT $ARG_UNFINALIZED
+
+      - name: Destroy droplet
+        if: ${{ always() && steps.terraform_apply.outcome == 'success' }}
+        run: |
+          DROPLET_ID=${{ steps.terraform_apply.outputs.scraper_id }}
+          curl -X DELETE "https://api.digitalocean.com/v2/droplets/$DROPLET_ID" \
+          -H "Authorization: Bearer ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" \
+          -H "Content-Type: application/json"

--- a/.github/workflows/repull_tournament.yml
+++ b/.github/workflows/repull_tournament.yml
@@ -1,0 +1,120 @@
+name: Repull Tournament
+
+on:
+  workflow_dispatch:
+    inputs:
+      tournament_ids:
+        description: "Tournament IDs to re-pull (comma or space separated)"
+        required: true
+        type: string
+      log_level:
+        description: "Log verbosity for the re-pull command"
+        required: false
+        default: "INFO"
+        type: choice
+        options:
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+          - CRITICAL
+
+jobs:
+  repull:
+    runs-on: ubuntu-latest
+    environment: Scraper
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Get self ip
+        id: self_ip
+        run: |
+          SELF_IP=$(curl -s https://api.ipify.org)
+          echo "self_ip=$SELF_IP" >> $GITHUB_OUTPUT
+
+      - name: Terraform Init
+        working-directory: terraform/scraper
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: terraform/scraper
+        run: terraform plan -out=tfplan -input=false
+        env:
+          TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          TF_VAR_source_ip: ${{ steps.self_ip.outputs.self_ip }}
+          TF_VAR_joy_ip: ${{ secrets.JOY_IP }}
+
+      - name: Terraform Apply
+        id: terraform_apply
+        working-directory: terraform/scraper
+        run: |
+          terraform apply -auto-approve tfplan
+          SCRAPER_IP=$(terraform output -raw scraper_ip)
+          SCRAPER_ID=$(terraform output -raw scraper_id)
+          echo "scraper_ip=$SCRAPER_IP" >> $GITHUB_OUTPUT
+          echo "scraper_id=$SCRAPER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for droplet
+        run: sleep 90
+
+      - name: Run re-pull command
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ steps.terraform_apply.outputs.scraper_ip }}
+          username: root
+          key: ${{ secrets.DIGITALOCEAN_SSH_KEY_ED }}
+          script: |
+            set +o histexpand || true
+            export PATH=$PATH:/usr/bin
+            export DO_API_TOKEN='${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}'
+            export RANKINGS_DATABASE_URL='${{ secrets.RANKINGS_DATABASE_URL }}'
+            export RANKINGS_DB_SCHEMA='${{ secrets.RANKINGS_DB_SCHEMA }}'
+            export SENDOU_KEY='${{ secrets.SENDOU_KEY }}'
+            export SENTRY_DSN='${{ secrets.SENTRY_DSN }}'
+
+            if [ -z "$RANKINGS_DATABASE_URL" ]; then
+              echo "RANKINGS_DATABASE_URL secret is required" >&2
+              exit 1
+            fi
+            if [ -z "$SENDOU_KEY" ]; then
+              echo "SENDOU_KEY secret is required" >&2
+              exit 1
+            fi
+
+            RAW_IDS="${{ inputs.tournament_ids }}"
+            TOURNAMENT_IDS=$(echo "$RAW_IDS" | tr ',' ' ' | xargs)
+            if [ -z "$TOURNAMENT_IDS" ]; then
+              echo "No tournament IDs provided" >&2
+              exit 1
+            fi
+
+            LOG_LEVEL='${{ inputs.log_level }}'
+
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+
+            docker login -u "$DO_API_TOKEN" -p "$DO_API_TOKEN" registry.digitalocean.com/sendouq
+            docker pull registry.digitalocean.com/sendouq/scraper:latest
+
+            docker run --rm \
+              -e RANKINGS_DATABASE_URL \
+              -e RANKINGS_DB_SCHEMA \
+              -e SENDOU_KEY \
+              -e SENTRY_DSN \
+              --entrypoint poetry \
+              registry.digitalocean.com/sendouq/scraper:latest \
+              run rankings_repull --log-level "$LOG_LEVEL" $TOURNAMENT_IDS
+
+      - name: Destroy droplet
+        if: ${{ always() && steps.terraform_apply.outcome == 'success' }}
+        run: |
+          DROPLET_ID=${{ steps.terraform_apply.outputs.scraper_id }}
+          curl -X DELETE "https://api.digitalocean.com/v2/droplets/$DROPLET_ID" \
+          -H "Authorization: Bearer ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" \
+          -H "Content-Type: application/json"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ Docker
   - To emit Parquet snapshots from the updater container, set `WRITE_PARQUET=true`.
   ```
 
+- **Re-scrape specific tournaments and import into the rankings DB:**
+  ```bash
+  poetry run rankings_repull 2511 2433
+  ```
+  Ensure `SENDOU_KEY` and `RANKINGS_DATABASE_URL`/`RANKINGS_DB_SCHEMA` are exported so the command can talk to the public API and the database. The command snapshots existing data and rolls it back automatically if the import fails.
+
+- **Fix tournaments missing roster data:**
+  ```bash
+  poetry run rankings_fix_tournaments --limit 10
+  ```
+  The command identifies tournaments with zero roster entries (defaulting to finalized ones), re-scrapes them, and reimports into Postgres. Use `--include-unfinalized` if you want to inspect in-progress events too. Existing data is restored automatically if the refresh fails mid-run.
+
 ### Running the Dashboard
 
 - **With Poetry:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ rankings_compile = "rankings.cli.compile:main"
 rankings_update = "rankings.cli.update:main"
 rankings_db_init = "rankings.cli.db_init:main"
 rankings_pull = "rankings.cli.pull:main"
+rankings_repull = "rankings.cli.repull:main"
+rankings_fix_tournaments = "rankings.cli.fix_tournaments:main"
 rankings_db_schema = "rankings.cli.schema:main"
 
 [tool.black]

--- a/src/rankings/cli/fix_tournaments.py
+++ b/src/rankings/cli/fix_tournaments.py
@@ -114,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             payloads.append(_scrape_with_players(tid, session=session))
             logger.info("Fetched tournament %s", tid)
-        except Exception as exc:  # noqa: BLE001
+        except requests.RequestException as exc:
             logger.error("Failed to scrape tournament %s: %s", tid, exc)
             return 1
 

--- a/src/rankings/cli/fix_tournaments.py
+++ b/src/rankings/cli/fix_tournaments.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import requests
+from sqlalchemy import text
+
+from rankings.cli.repull import (
+    import_with_rollback,
+    _scrape_with_players,
+)
+from rankings.sql import create_all as rankings_create_all
+from rankings.sql import create_engine as rankings_create_engine
+from rankings.sql.constants import SCHEMA as RANKINGS_SCHEMA
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-scrape tournaments that have zero roster entries recorded in the "
+            "rankings database."
+        )
+    )
+    parser.add_argument(
+        "--db-url",
+        dest="db_url",
+        default=None,
+        help=(
+            "Override database URL. Defaults to env RANKINGS_DATABASE_URL or "
+            "DATABASE_URL"
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional maximum number of tournaments to re-pull.",
+    )
+    parser.add_argument(
+        "--include-unfinalized",
+        action="store_true",
+        help="Also re-pull tournaments that are not marked finalized.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Log level for stdout output",
+    )
+    return parser.parse_args(argv)
+
+
+def _find_tournaments_without_players(
+    engine, *, include_unfinalized: bool, limit: int | None
+) -> list[int]:
+    where_clause = "" if include_unfinalized else "WHERE COALESCE(t.is_finalized, false) = true"
+    sql = f"""
+        SELECT t.tournament_id
+        FROM {RANKINGS_SCHEMA}.tournaments AS t
+        LEFT JOIN {RANKINGS_SCHEMA}.roster_entries AS r
+            ON r.tournament_id = t.tournament_id
+        {where_clause}
+        GROUP BY t.tournament_id
+        HAVING COUNT(r.player_id) = 0
+        ORDER BY t.start_time_ms DESC NULLS LAST
+    """
+    if limit and limit > 0:
+        sql += " LIMIT :limit"
+    params: dict[str, int] = {}
+    if limit and limit > 0:
+        params["limit"] = int(limit)
+
+    with engine.connect() as conn:
+        result = conn.execute(text(sql), params)
+        return [int(row[0]) for row in result]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    engine = rankings_create_engine(args.db_url)
+    rankings_create_all(engine)
+
+    target_ids = _find_tournaments_without_players(
+        engine,
+        include_unfinalized=args.include_unfinalized,
+        limit=args.limit,
+    )
+
+    if not target_ids:
+        logger.info("No tournaments found without roster entries; nothing to do.")
+        return 0
+
+    logger.info("Found %d tournament(s) without roster entries: %s", len(target_ids), target_ids)
+
+    session = requests.Session()
+    payloads = []
+    for tid in target_ids:
+        try:
+            payloads.append(_scrape_with_players(tid, session=session))
+            logger.info("Fetched tournament %s", tid)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to scrape tournament %s: %s", tid, exc)
+            return 1
+
+    try:
+        inserted = import_with_rollback(
+            engine, payloads, target_ids, log=logger
+        )
+    except Exception:
+        return 1
+
+    logger.info(
+        "Re-imported %d tournament(s); import attempted %d row groups",
+        len(payloads),
+        inserted,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rankings/cli/fix_tournaments.py
+++ b/src/rankings/cli/fix_tournaments.py
@@ -7,10 +7,7 @@ import sys
 import requests
 from sqlalchemy import text
 
-from rankings.cli.repull import (
-    import_with_rollback,
-    _scrape_with_players,
-)
+from rankings.cli.repull import _scrape_with_players, import_with_rollback
 from rankings.sql import create_all as rankings_create_all
 from rankings.sql import create_engine as rankings_create_engine
 from rankings.sql.constants import SCHEMA as RANKINGS_SCHEMA
@@ -57,7 +54,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _find_tournaments_without_players(
     engine, *, include_unfinalized: bool, limit: int | None
 ) -> list[int]:
-    where_clause = "" if include_unfinalized else "WHERE COALESCE(t.is_finalized, false) = true"
+    where_clause = (
+        ""
+        if include_unfinalized
+        else "WHERE COALESCE(t.is_finalized, false) = true"
+    )
     sql = f"""
         SELECT t.tournament_id
         FROM {RANKINGS_SCHEMA}.tournaments AS t
@@ -96,10 +97,16 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if not target_ids:
-        logger.info("No tournaments found without roster entries; nothing to do.")
+        logger.info(
+            "No tournaments found without roster entries; nothing to do."
+        )
         return 0
 
-    logger.info("Found %d tournament(s) without roster entries: %s", len(target_ids), target_ids)
+    logger.info(
+        "Found %d tournament(s) without roster entries: %s",
+        len(target_ids),
+        target_ids,
+    )
 
     session = requests.Session()
     payloads = []

--- a/src/rankings/cli/repull.py
+++ b/src/rankings/cli/repull.py
@@ -350,7 +350,7 @@ def main(argv: list[str] | None = None) -> int:
     for tid in args.tournament_ids:
         try:
             payload = _scrape_with_players(tid, session=session)
-        except Exception as exc:  # noqa: BLE001
+        except requests.RequestException as exc:
             logger.error("Failed to scrape tournament %s: %s", tid, exc)
             return 1
         payloads.append(payload)

--- a/src/rankings/cli/repull.py
+++ b/src/rankings/cli/repull.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Iterable
+
+import requests
+from sqlalchemy import delete, select
+
+from rankings.cli import db_import as import_cli
+from rankings.scraping.api import scrape_tournament
+from rankings.scraping.calendar_api import fetch_tournament_players
+from rankings.sql import create_all as rankings_create_all
+from rankings.sql import create_engine as rankings_create_engine
+from rankings.sql import models as RM
+
+logger = logging.getLogger(__name__)
+
+
+def _scrape_with_players(
+    tournament_id: int, session: requests.Session
+) -> dict:
+    """Fetch tournament payload and enrich it with player matches when available."""
+    payload = scrape_tournament(tournament_id, session=session)
+    try:
+        players_payload = fetch_tournament_players(tournament_id)
+    except Exception as exc:  # noqa: BLE001 - keep going on partial fetch
+        logger.warning(
+            "Players route fetch failed for %s: %s", tournament_id, exc
+        )
+    else:
+        if players_payload:
+            payload["player_matches"] = players_payload
+    return payload
+
+
+def _import_payloads(engine, payloads: Iterable[dict]) -> int:
+    """Import payloads into the rankings schema."""
+    payload_list = list(payloads)
+    if not payload_list:
+        return 0
+    return import_cli.import_file(engine, payload_list)
+
+
+def _row_to_dict(row) -> dict:
+    mapping = row._mapping if hasattr(row, "_mapping") else row
+    return dict(mapping)
+
+
+def _snapshot_for_rollback(engine, tournament_ids: list[int]) -> dict[str, list[dict]]:
+    if not tournament_ids:
+        return {
+            "tournaments": [],
+            "stages": [],
+            "groups": [],
+            "rounds": [],
+            "teams": [],
+            "matches": [],
+            "roster_entries": [],
+            "player_appearances": [],
+        }
+
+    tids = [int(t) for t in tournament_ids]
+    snapshot: dict[str, list[dict]] = {}
+
+    with engine.connect() as conn:
+        tournament_table = RM.Tournament.__table__
+        stage_table = RM.Stage.__table__
+        group_table = RM.Group.__table__
+        round_table = RM.Round.__table__
+        team_table = RM.TournamentTeam.__table__
+        match_table = RM.Match.__table__
+        roster_table = RM.RosterEntry.__table__
+        appearance_table = RM.PlayerAppearance.__table__
+
+        snapshot["tournaments"] = [
+            _row_to_dict(row)
+            for row in conn.execute(
+                select(tournament_table).where(
+                    tournament_table.c.tournament_id.in_(tids)
+                )
+            )
+        ]
+
+        stage_rows = list(
+            conn.execute(
+                select(stage_table).where(stage_table.c.tournament_id.in_(tids))
+            )
+        )
+        snapshot["stages"] = [_row_to_dict(row) for row in stage_rows]
+        stage_ids = [row[stage_table.c.stage_id] for row in stage_rows]
+
+        if stage_ids:
+            group_rows = list(
+                conn.execute(
+                    select(group_table).where(group_table.c.stage_id.in_(stage_ids))
+                )
+            )
+            snapshot["groups"] = [_row_to_dict(row) for row in group_rows]
+            group_ids = [row[group_table.c.group_id] for row in group_rows]
+
+            round_rows = list(
+                conn.execute(
+                    select(round_table).where(
+                        round_table.c.stage_id.in_(stage_ids)
+                    )
+                )
+            )
+            snapshot["rounds"] = [_row_to_dict(row) for row in round_rows]
+        else:
+            snapshot["groups"] = []
+            snapshot["rounds"] = []
+
+        snapshot["teams"] = [
+            _row_to_dict(row)
+            for row in conn.execute(
+                select(team_table).where(team_table.c.tournament_id.in_(tids))
+            )
+        ]
+
+        snapshot["matches"] = [
+            _row_to_dict(row)
+            for row in conn.execute(
+                select(match_table).where(match_table.c.tournament_id.in_(tids))
+            )
+        ]
+
+        snapshot["roster_entries"] = [
+            _row_to_dict(row)
+            for row in conn.execute(
+                select(roster_table).where(roster_table.c.tournament_id.in_(tids))
+            )
+        ]
+
+        snapshot["player_appearances"] = [
+            _row_to_dict(row)
+            for row in conn.execute(
+                select(appearance_table).where(
+                    appearance_table.c.tournament_id.in_(tids)
+                )
+            )
+        ]
+
+    return snapshot
+
+
+def _delete_current_state(conn, tournament_ids: list[int]) -> None:
+    if not tournament_ids:
+        return
+
+    tids = [int(t) for t in tournament_ids]
+    tournament_table = RM.Tournament.__table__
+    stage_table = RM.Stage.__table__
+    group_table = RM.Group.__table__
+    round_table = RM.Round.__table__
+    team_table = RM.TournamentTeam.__table__
+    match_table = RM.Match.__table__
+    roster_table = RM.RosterEntry.__table__
+    appearance_table = RM.PlayerAppearance.__table__
+
+    stage_rows = list(
+        conn.execute(
+            select(stage_table.c.stage_id).where(stage_table.c.tournament_id.in_(tids))
+        )
+    )
+    stage_ids = [row[0] for row in stage_rows]
+
+    group_ids: list[int] = []
+    round_ids: list[int] = []
+    if stage_ids:
+        group_rows = list(
+            conn.execute(
+                select(group_table.c.group_id).where(
+                    group_table.c.stage_id.in_(stage_ids)
+                )
+            )
+        )
+        group_ids = [row[0] for row in group_rows]
+
+        round_rows = list(
+            conn.execute(
+                select(round_table.c.round_id).where(
+                    round_table.c.stage_id.in_(stage_ids)
+                )
+            )
+        )
+        round_ids = [row[0] for row in round_rows]
+
+    conn.execute(
+        delete(appearance_table).where(appearance_table.c.tournament_id.in_(tids))
+    )
+    conn.execute(
+        delete(roster_table).where(roster_table.c.tournament_id.in_(tids))
+    )
+    conn.execute(
+        delete(match_table).where(match_table.c.tournament_id.in_(tids))
+    )
+    if round_ids:
+        conn.execute(delete(round_table).where(round_table.c.round_id.in_(round_ids)))
+    if group_ids:
+        conn.execute(delete(group_table).where(group_table.c.group_id.in_(group_ids)))
+    if stage_ids:
+        conn.execute(delete(stage_table).where(stage_table.c.stage_id.in_(stage_ids)))
+    conn.execute(
+        delete(team_table).where(team_table.c.tournament_id.in_(tids))
+    )
+    conn.execute(
+        delete(tournament_table).where(tournament_table.c.tournament_id.in_(tids))
+    )
+
+
+def _restore_snapshot(engine, snapshot: dict[str, list[dict]], tournament_ids: list[int]) -> None:
+    if not tournament_ids:
+        return
+
+    with engine.begin() as conn:
+        _delete_current_state(conn, tournament_ids)
+
+        def _insert_rows(table, rows):
+            if rows:
+                conn.execute(table.insert(), rows)
+
+        tournament_table = RM.Tournament.__table__
+        stage_table = RM.Stage.__table__
+        group_table = RM.Group.__table__
+        round_table = RM.Round.__table__
+        team_table = RM.TournamentTeam.__table__
+        match_table = RM.Match.__table__
+        roster_table = RM.RosterEntry.__table__
+        appearance_table = RM.PlayerAppearance.__table__
+
+        _insert_rows(tournament_table, snapshot.get("tournaments", []))
+        _insert_rows(stage_table, snapshot.get("stages", []))
+        _insert_rows(group_table, snapshot.get("groups", []))
+        _insert_rows(round_table, snapshot.get("rounds", []))
+        _insert_rows(team_table, snapshot.get("teams", []))
+        _insert_rows(match_table, snapshot.get("matches", []))
+        _insert_rows(roster_table, snapshot.get("roster_entries", []))
+        _insert_rows(appearance_table, snapshot.get("player_appearances", []))
+
+
+def import_with_rollback(
+    engine, payloads: Iterable[dict], tournament_ids: list[int], *, log: logging.Logger
+) -> int:
+    snapshot = _snapshot_for_rollback(engine, tournament_ids)
+    try:
+        return _import_payloads(engine, payloads)
+    except Exception as exc:
+        log.error(
+            "Import failed for tournaments %s; attempting rollback: %s",
+            tournament_ids,
+            exc,
+        )
+        try:
+            _restore_snapshot(engine, snapshot, tournament_ids)
+        except Exception as restore_exc:  # pragma: no cover - best effort
+            log.error(
+                "Rollback failed for tournaments %s: %s",
+                tournament_ids,
+                restore_exc,
+            )
+        raise
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-scrape tournaments from Sendou and import them into the "
+            "rankings database."
+        )
+    )
+    parser.add_argument(
+        "tournament_ids",
+        nargs="+",
+        type=int,
+        help="One or more tournament IDs to refresh",
+    )
+    parser.add_argument(
+        "--db-url",
+        dest="db_url",
+        default=None,
+        help=(
+            "Override database URL. Defaults to env RANKINGS_DATABASE_URL or "
+            "DATABASE_URL"
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Log level for stdout output",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    session = requests.Session()
+    engine = rankings_create_engine(args.db_url)
+    rankings_create_all(engine)
+
+    payloads = []
+    for tid in args.tournament_ids:
+        try:
+            payload = _scrape_with_players(tid, session=session)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to scrape tournament %s: %s", tid, exc)
+            return 1
+        payloads.append(payload)
+        logger.info("Fetched tournament %s", tid)
+
+    try:
+        inserted = import_with_rollback(
+            engine, payloads, [int(t) for t in args.tournament_ids], log=logger
+        )
+    except Exception:
+        return 1
+
+    logger.info(
+        "Ingestion complete for %d tournament(s); import attempted %d row groups",
+        len(payloads),
+        inserted,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rankings/cli/repull.py
+++ b/src/rankings/cli/repull.py
@@ -23,7 +23,7 @@ def _scrape_with_players(tournament_id: int, session: requests.Session) -> dict:
     payload = scrape_tournament(tournament_id, session=session)
     try:
         players_payload = fetch_tournament_players(tournament_id)
-    except Exception as exc:  # noqa: BLE001 - keep going on partial fetch
+    except requests.RequestException as exc:  # keep going on partial fetch
         logger.warning(
             "Players route fetch failed for %s: %s", tournament_id, exc
         )

--- a/src/rankings/core/sentry.py
+++ b/src/rankings/core/sentry.py
@@ -104,11 +104,12 @@ def init_sentry(
     dsn = _first_env(dsn_envs)
     if not dsn:
         _LOG.info(
-            "Sentry disabled: no DSN configured (checked envs=%s)", list(dsn_envs)
+            "Sentry disabled: no DSN configured (checked envs=%s)",
+            list(dsn_envs),
         )
         return False
     # Be resilient to accidental quotes/whitespace in env secret values
-    dsn = dsn.strip().strip("\"").strip("'")
+    dsn = dsn.strip().strip('"').strip("'")
     if not _is_valid_dsn(dsn):
         _LOG.info("Sentry disabled: DSN appears invalid; check secrets/env")
         return False

--- a/src/rankings/sql/views.py
+++ b/src/rankings/sql/views.py
@@ -95,7 +95,9 @@ def ensure_tournament_event_times_view(
             return
 
         with engine.begin() as connection:
-            logger.info("Ensuring tournament_event_times materialized view exists")
+            logger.info(
+                "Ensuring tournament_event_times materialized view exists"
+            )
             connection.execute(db.text(_event_times_view_sql(schema)))
             for statement in _event_times_indexes(schema):
                 connection.execute(db.text(statement))


### PR DESCRIPTION
This pull request introduces new functionality for re-scraping and repairing tournament data in the rankings database, along with automation via GitHub Actions. The main changes include two new CLI commands for re-pulling tournaments and fixing tournaments missing roster data, corresponding workflow automation, and updates to documentation and project configuration. These changes enable easier maintenance and recovery of tournament data, improving reliability and operational efficiency.

**New CLI commands for tournament data maintenance:**

* Added `rankings_repull` CLI command (`src/rankings/cli/repull.py`), which re-scrapes specified tournaments from the Sendou API, imports them into the rankings database, and rolls back changes automatically if the import fails.
* Added `rankings_fix_tournaments` CLI command (`src/rankings/cli/fix_tournaments.py`), which identifies tournaments with zero roster entries, re-scrapes them, and attempts to re-import, including an option to process unfinalized tournaments. Rollback is also supported if import fails.
* Registered both commands as entry points in `pyproject.toml` for direct invocation.

**Automation via GitHub Actions:**

* Added `.github/workflows/repull_tournament.yml` workflow to automate re-pulling tournaments using the new CLI command, with input options for tournament IDs and log level.
* Added `.github/workflows/fix_tournaments.yml` workflow to automate the fixing of tournaments missing roster data, supporting options for limit, inclusion of unfinalized tournaments, and log verbosity.

**Documentation updates:**

* Updated `README.md` to document usage of the new CLI commands for re-pulling tournaments and fixing tournaments missing roster data, including usage notes and options.